### PR TITLE
add license headers to all files

### DIFF
--- a/source/controller.cpp
+++ b/source/controller.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #include "controller.hpp"
 #include "script_init.hpp"
 #include "script_provider.hpp"

--- a/source/controller.hpp
+++ b/source/controller.hpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #pragma once
 #include <switch.h>
 #include <cstring>

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 // Include the most common headers from the C standard library
 #include <stdio.h>
 #include <stdlib.h>

--- a/source/script_init.cpp
+++ b/source/script_init.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #include <cstring>
 #include <cstdlib>
 #include <cstdint>

--- a/source/script_init.hpp
+++ b/source/script_init.hpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #pragma once
 #include <cstring>
 #include <cstdlib>

--- a/source/script_populator.cpp
+++ b/source/script_populator.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #include <cstdlib>
 #include <thread>
 #include <mutex>

--- a/source/script_populator.hpp
+++ b/source/script_populator.hpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #pragma once
 #include <memory>
 #include <thread>

--- a/source/script_provider.cpp
+++ b/source/script_provider.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #include <cstring>
 #include <cstdlib>
 #include "script_init.hpp"

--- a/source/script_provider.hpp
+++ b/source/script_provider.hpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #pragma once
 #include <string>
 #include <queue>


### PR DESCRIPTION
Hi there! Just saw your cool repo via the DMCA takedown notice you sent. I made this PR to try to prevent this situation from happening again. SPDX License Identifiers are an [unambiguous standard](https://spdx.dev/resources/use/#identifiers) that are easy to comply with: just keep the comments. Unless you want to argue in court that copying an SPDX Identifier but not the full license text violates the GPLv2, this should suffice to make sure people include the license in their clones/copies/forks etc.

Open question: As you seemed to have no prior license headers (I only checked the latest commit so let me know if I'm wrong) I didn't know if you meant "GPL-2.0-or-later" or "GPL-2.0-only". Please clarify if you want to allow people to distribute this under the terms of the GPLv3.